### PR TITLE
Changed Runner#run_all to run each test file under 'test' directory

### DIFF
--- a/lib/guard/spin/runner.rb
+++ b/lib/guard/spin/runner.rb
@@ -30,7 +30,7 @@ module Guard
         if rspec?
           run(['spec'])
         elsif test_unit?
-          run(['test'])
+          run(Dir['test/**/*_test.rb']+Dir['test/**/test_*.rb'])
         end
       end
 

--- a/spec/guard/spin/runner_spec.rb
+++ b/spec/guard/spin/runner_spec.rb
@@ -149,10 +149,15 @@ describe Guard::Spin::Runner do
     end
 
     context 'with test_unit' do
-      it "calls Runner.run with \"['test']\"" do
+      before do
+        Dir.should_receive(:[]).with('test/**/*_test.rb').once.and_return(%w{test/unit/foo_test.rb test/functional/bar_test.rb})
+        Dir.should_receive(:[]).with('test/**/test_*.rb').once.and_return(['test/unit/test_baz.rb'])
+      end
+      
+      it "calls Runner.run with each test file" do
         subject.stub(:rspec?).and_return(false)
         subject.stub(:test_unit?).and_return(true)
-        subject.should_receive(:run).with(['test'])
+        subject.should_receive(:run).with(%w{test/unit/foo_test.rb test/functional/bar_test.rb test/unit/test_baz.rb})
         subject.run_all
       end
     end


### PR DESCRIPTION
For `Test::Unit` test, spin must load each file individually (unfortunately). I added code to pull in each individual test file under the `test` directory.
