### PR TITLE
fixed guardfile evaluating vim .swp files

### DIFF
--- a/lib/guard/spin/templates/Guardfile
+++ b/lib/guard/spin/templates/Guardfile
@@ -1,16 +1,16 @@
 guard 'spin' do
   # uses the .rspec file
   # --colour --fail-fast --format documentation --tag ~slow
-  watch(%r{^spec/.+_spec\.rb})
-  watch(%r{^app/(.+)\.rb})                           { |m| "spec/#{m[1]}_spec.rb" }
-  watch(%r{^app/(.+)\.haml})                         { |m| "spec/#{m[1]}.haml_spec.rb" }
-  watch(%r{^lib/(.+)\.rb})                           { |m| "spec/lib/#{m[1]}_spec.rb" }
-  watch(%r{^app/controllers/(.+)_(controller)\.rb})  { |m| ["spec/routing/#{m[1]}_routing_spec.rb", "spec/#{m[2]}s/#{m[1]}_#{m[2]}_spec.rb", "spec/requests/#{m[1]}_spec.rb"] }
+  watch(%r{^spec/.+_spec\.rb$})
+  watch(%r{^app/(.+)\.rb$})                           { |m| "spec/#{m[1]}_spec.rb" }
+  watch(%r{^app/(.+)\.haml$})                         { |m| "spec/#{m[1]}.haml_spec.rb" }
+  watch(%r{^lib/(.+)\.rb$})                           { |m| "spec/lib/#{m[1]}_spec.rb" }
+  watch(%r{^app/controllers/(.+)_(controller)\.rb$})  { |m| ["spec/routing/#{m[1]}_routing_spec.rb", "spec/#{m[2]}s/#{m[1]}_#{m[2]}_spec.rb", "spec/requests/#{m[1]}_spec.rb"] }
   
   # TestUnit
-  # watch(%r|^test/(.*)_test\.rb|)
-  # watch(%r|^lib/(.*)([^/]+)\.rb|)     { |m| "test/#{m[1]}test_#{m[2]}.rb" }
-  # watch(%r|^test/test_helper\.rb|)    { "test" }
-  # watch(%r|^app/controllers/(.*)\.rb|) { |m| "test/functional/#{m[1]}_test.rb" }
-  # watch(%r|^app/models/(.*)\.rb|)      { |m| "test/unit/#{m[1]}_test.rb" }
+  # watch(%r|^test/(.*)_test\.rb$|)
+  # watch(%r|^lib/(.*)([^/]+)\.rb$|)     { |m| "test/#{m[1]}test_#{m[2]}.rb" }
+  # watch(%r|^test/test_helper\.rb$|)    { "test" }
+  # watch(%r|^app/controllers/(.*)\.rb$|) { |m| "test/functional/#{m[1]}_test.rb" }
+  # watch(%r|^app/models/(.*)\.rb$|)      { |m| "test/unit/#{m[1]}_test.rb" }
 end


### PR DESCRIPTION
Hi,

The generated Guardfile code evaluates vim's .swp files since there isn't a dollar sign after the file extension for each file it watches. For example, if you edit app/controllers/items_controller.rb in vim, spin loads app/controllers/items_controller.rb and app/controllers/items_controller.rb.swp as well. I added a dollar sign to every line watched so it doesn't do this.
