### PR TITLE
Get rid of non-sensical guard deprecation while maintaining backwards-com...

### DIFF
--- a/lib/guard/spin.rb
+++ b/lib/guard/spin.rb
@@ -36,5 +36,12 @@ module Guard
       runner.kill_spin
     end
 
+    def respond_to?(name)
+      if name == :run_on_change
+        false
+      else
+        super
+      end
+    end
   end
 end


### PR DESCRIPTION
It kind of is a hack, but it works with both the old and new api without warnings.

I also filed an issue with guard to get rid of that deprecation: https://github.com/guard/guard/issues/298
