### PR TITLE
Add an option to take paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Available options:
 :test_unit => false      # Don't use Test::Unit
 :bundler => false        # Don't use "bundle exec"
 :cli => '--time'         # Pass options to spin serve. `spin -h` for more spin options
+:spec_paths => ["spec"]  # specify an array of paths that contain spec files
 :run_all => true         # Run all tests when hitting enter in guard
 ```
 

--- a/lib/guard/spin/runner.rb
+++ b/lib/guard/spin/runner.rb
@@ -23,7 +23,8 @@ module Guard
       end
 
       def run(paths)
-        run_command spin_push_command(paths), spin_push_options
+        paths_opts = options[:spec_paths] ? [options[:spec_paths]].flatten : paths
+        run_command spin_push_command(paths_opts), spin_push_options
       end
 
       def run_all

--- a/lib/guard/spin/runner.rb
+++ b/lib/guard/spin/runner.rb
@@ -24,7 +24,8 @@ module Guard
 
       def run(paths)
         paths_opts = options[:spec_paths] ? [options[:spec_paths]].flatten : paths
-        run_command spin_push_command(paths_opts), spin_push_options
+        paths_opts.reject!{ |path| !FileTest.exists? path }
+        run_command(spin_push_command(paths_opts), spin_push_options) if paths_opts.any?
       end
 
       def run_all


### PR DESCRIPTION
Hello,

I needed to run my specs of a specific dir so I've add an option to your gem to do this, like the guard-rspec gem do.

If you have any question, ask me.
