### PR TITLE
Update guard-spin to use new Guard plugin method

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 Gemfile.lock
 pkg/*
 tmp/*
+vendor/bundle

--- a/guard-spin.gemspec
+++ b/guard-spin.gemspec
@@ -11,11 +11,12 @@ Gem::Specification.new do |gem|
   gem.summary       = %q{Pushes watched files to Spin}
   gem.homepage      = "http://github.com/vizjerai/guard-spin"
 
-  gem.add_dependency 'guard'
+  gem.add_dependency 'guard', '~> 2.8'
+  gem.add_dependency 'guard-compat', '~> 1.0'
   gem.add_dependency 'spin'
 
   gem.add_development_dependency 'bundler', '>= 1.0'
-  gem.add_development_dependency 'rspec', '>= 2.0'
+  gem.add_development_dependency 'rspec', '>= 3.2'
 
   gem.files         = Dir.glob('{lib}/**/*') + %w[LICENSE README.md]
   gem.require_path  = 'lib'

--- a/lib/guard/spin.rb
+++ b/lib/guard/spin.rb
@@ -1,13 +1,13 @@
 require 'guard'
-require 'guard/guard'
+require 'guard/plugin'
 
 module Guard
-  class Spin < Guard
+  class Spin < Plugin
 
     autoload :Runner, 'guard/spin/runner'
     attr_accessor :runner
 
-    def initialize(watchers=[], options={})
+    def initialize(options={})
       super
       @runner = Runner.new(options)
     end

--- a/lib/guard/spin/version.rb
+++ b/lib/guard/spin/version.rb
@@ -1,5 +1,5 @@
 module Guard
   module SpinVersion
-    VERSION = "0.3.0"
+    VERSION = "0.4.0"
   end
 end

--- a/spec/guard/spin/runner_spec.rb
+++ b/spec/guard/spin/runner_spec.rb
@@ -7,12 +7,12 @@ describe Guard::Spin::Runner do
     subject { runner.options }
 
     context 'with default options' do
-      it { should == {:run_all => true} }
+      it { is_expected.to eq({:run_all => true}) }
     end
 
     context 'with run_all => false' do
       let(:runner) { Guard::Spin::Runner.new :run_all => false }
-      it { should == {:run_all => false} }
+      it { is_expected.to eq({:run_all => false}) }
     end
   end
 
@@ -21,65 +21,65 @@ describe Guard::Spin::Runner do
       subject { Guard::Spin::Runner.new :cli => '--time' }
 
       before do
-        subject.should_receive(:test_unit?).any_number_of_times.and_return(false)
-        subject.should_receive(:rspec?).any_number_of_times.and_return(true)
-        subject.should_receive(:bundler?).any_number_of_times.and_return(false)
+        allow(subject).to receive(:test_unit?).and_return(false)
+        allow(subject).to receive(:rspec?).and_return(true)
+        allow(subject).to receive(:bundler?).and_return(false)
       end
 
       it "launches spin server with cli options" do
-        subject.should_receive(:spawn_spin).with("spin serve", "--time")
+        expect(subject).to receive(:spawn_spin).with("spin serve", "--time")
         subject.launch_spin('Start')
       end
     end
 
     context 'with Test::Unit only' do
       before do
-        subject.should_receive(:test_unit?).any_number_of_times.and_return(true)
-        subject.should_receive(:rspec?).any_number_of_times.and_return(false)
-        subject.should_receive(:bundler?).any_number_of_times.and_return(false)
+        allow(subject).to receive(:test_unit?).and_return(true)
+        allow(subject).to receive(:rspec?).and_return(false)
+        allow(subject).to receive(:bundler?).and_return(false)
       end
 
       it "launches Spin server for Test::Unit" do
-        subject.should_receive(:spawn_spin).with("spin serve", "-Itest")
+        expect(subject).to receive(:spawn_spin).with("spin serve", "-Itest")
         subject.launch_spin('Start')
       end
     end
 
     context 'with Test::Unit and Bundler' do
       before do
-        subject.should_receive(:test_unit?).any_number_of_times.and_return(true)
-        subject.should_receive(:rspec?).any_number_of_times.and_return(false)
-        subject.should_receive(:bundler?).any_number_of_times.and_return(true)
+        allow(subject).to receive(:test_unit?).and_return(true)
+        allow(subject).to receive(:rspec?).and_return(false)
+        allow(subject).to receive(:bundler?).and_return(true)
       end
 
       it "launches Spin server for Test::Unit with 'bundle exec'" do
-        subject.should_receive(:spawn_spin).with("bundle exec spin serve", "-Itest")
+        expect(subject).to receive(:spawn_spin).with("bundle exec spin serve", "-Itest")
         subject.launch_spin('Start')
       end
     end
 
     context 'with RSpec only' do
       before do
-        subject.should_receive(:test_unit?).any_number_of_times.and_return(false)
-        subject.should_receive(:rspec?).any_number_of_times.and_return(true)
-        subject.should_receive(:bundler?).any_number_of_times.and_return(false)
+        allow(subject).to receive(:test_unit?).and_return(false)
+        allow(subject).to receive(:rspec?).and_return(true)
+        allow(subject).to receive(:bundler?).and_return(false)
       end
 
       it "launches Spin server for RSpec" do
-        subject.should_receive(:spawn_spin).with("spin serve", "")
+        expect(subject).to receive(:spawn_spin).with("spin serve", "")
         subject.launch_spin('Start')
       end
     end
 
     context 'with Rspec and Bundler' do
       before do
-        subject.should_receive(:test_unit?).any_number_of_times.and_return(false)
-        subject.should_receive(:rspec?).any_number_of_times.and_return(true)
-        subject.should_receive(:bundler?).any_number_of_times.and_return(true)
+        allow(subject).to receive(:test_unit?).and_return(false)
+        allow(subject).to receive(:rspec?).and_return(true)
+        allow(subject).to receive(:bundler?).and_return(true)
       end
 
       it "launches Spin server for RSpec with 'bundle exec'" do
-        subject.should_receive(:spawn_spin).with("bundle exec spin serve", "")
+        expect(subject).to receive(:spawn_spin).with("bundle exec spin serve", "")
         subject.launch_spin('Start')
       end
     end
@@ -87,37 +87,37 @@ describe Guard::Spin::Runner do
 
   describe '.kill_spin' do
     it 'not call Process#kill with no spin_id' do
-      Process.should_not_receive(:kill)
+      expect(Process).not_to receive(:kill)
       subject.kill_spin
     end
 
     it "calls Process#kill with 'INT, pid'" do
-      subject.should_receive(:fork).and_return(123)
+      expect(subject).to receive(:fork).and_return(123)
       subject.send(:spawn_spin, '')
 
-      Process.should_receive(:kill).with(:INT, 123)
-      Process.should_receive(:waitpid).with(123, Process::WNOHANG).and_return(123)
-      Process.should_not_receive(:kill).with(:KILL, 123)
+      expect(Process).to receive(:kill).with(:INT, 123)
+      expect(Process).to receive(:waitpid).with(123, Process::WNOHANG).and_return(123)
+      expect(Process).not_to receive(:kill).with(:KILL, 123)
       subject.kill_spin
     end
 
     it "calls Process#kill with 'KILL, pid' if Process.waitpid returns nil" do
-      subject.should_receive(:fork).and_return(123)
+      expect(subject).to receive(:fork).and_return(123)
       subject.send(:spawn_spin, '')
 
-      Process.should_receive(:kill).with(:INT, 123)
-      Process.should_receive(:waitpid).with(123, Process::WNOHANG).and_return(nil)
-      Process.should_receive(:kill).with(:KILL, 123)
+      expect(Process).to receive(:kill).with(:INT, 123)
+      expect(Process).to receive(:waitpid).with(123, Process::WNOHANG).and_return(nil)
+      expect(Process).to receive(:kill).with(:KILL, 123)
       subject.kill_spin
     end
 
     it 'calls rescue when Process.waitpid raises Errno::ECHILD' do
-      subject.should_receive(:fork).and_return(123)
+      expect(subject).to receive(:fork).and_return(123)
       subject.send(:spawn_spin, '')
 
-      Process.should_receive(:kill).with(:INT, 123)
-      Process.should_receive(:waitpid).with(123, Process::WNOHANG).and_raise(Errno::ECHILD)
-      Process.should_not_receive(:kill).with(:KILL, 123)
+      expect(Process).to receive(:kill).with(:INT, 123)
+      expect(Process).to receive(:waitpid).with(123, Process::WNOHANG).and_raise(Errno::ECHILD)
+      expect(Process).not_to receive(:kill).with(:KILL, 123)
       subject.kill_spin
     end
   end
@@ -125,22 +125,22 @@ describe Guard::Spin::Runner do
   describe '.run' do
     context 'with Bundler' do
       before do
-        subject.should_receive(:bundler?).and_return(true)
+        expect(subject).to receive(:bundler?).and_return(true)
       end
 
       it 'pushes path to spin' do
-        subject.should_receive(:run_command).with('bundle exec spin push spec', '')
+        expect(subject).to receive(:run_command).with('bundle exec spin push spec', '')
         subject.run(['spec'])
       end
     end
 
     context 'without Bundler' do
       before do
-        subject.should_receive(:bundler?).and_return(false)
+        expect(subject).to receive(:bundler?).and_return(false)
       end
 
       it 'pushes path to spin' do
-        subject.should_receive(:run_command).with('spin push spec', '')
+        expect(subject).to receive(:run_command).with('spin push spec', '')
         subject.run(['spec'])
       end
     end
@@ -149,32 +149,32 @@ describe Guard::Spin::Runner do
   describe '.run_all' do
     context 'with rspec' do
       it "calls Runner.run with 'spec'" do
-        subject.stub(:rspec?).and_return(true)
-        subject.stub(:test_unit?).and_return(false)
-        subject.should_receive(:run).with(['spec'])
+        allow(subject).to receive(:rspec?).and_return(true)
+        allow(subject).to receive(:test_unit?).and_return(false)
+        expect(subject).to receive(:run).with(['spec'])
         subject.run_all
       end
     end
 
     context 'with test_unit' do
       before do
-        Dir.should_receive(:[]).with('test/**/*_test.rb').once.and_return(%w{test/unit/foo_test.rb test/functional/bar_test.rb})
-        Dir.should_receive(:[]).with('test/**/test_*.rb').once.and_return(['test/unit/test_baz.rb'])
+        expect(Dir).to receive(:[]).with('test/**/*_test.rb').once.and_return(%w{test/unit/foo_test.rb test/functional/bar_test.rb})
+        expect(Dir).to receive(:[]).with('test/**/test_*.rb').once.and_return(['test/unit/test_baz.rb'])
       end
-      
+
       it "calls Runner.run with each test file" do
-        subject.stub(:rspec?).and_return(false)
-        subject.stub(:test_unit?).and_return(true)
-        subject.should_receive(:run).with(%w{test/unit/foo_test.rb test/functional/bar_test.rb test/unit/test_baz.rb})
+        allow(subject).to receive(:rspec?).and_return(false)
+        allow(subject).to receive(:test_unit?).and_return(true)
+        expect(subject).to receive(:run).with(%w{test/unit/foo_test.rb test/functional/bar_test.rb test/unit/test_baz.rb})
         subject.run_all
       end
     end
 
     context 'with neither' do
       it 'not call Runner.run' do
-        subject.stub(:rspec?).and_return(false)
-        subject.stub(:test_unit?).and_return(false)
-        subject.should_not_receive(:run)
+        allow(subject).to receive(:rspec?).and_return(false)
+        allow(subject).to receive(:test_unit?).and_return(false)
+        expect(subject).not_to receive(:run)
         subject.run_all
       end
     end
@@ -182,8 +182,8 @@ describe Guard::Spin::Runner do
     context 'with :run_all set to false' do
       let(:runner) { Guard::Spin::Runner.new :run_all => false }
       it 'not run all specs' do
-        runner.stub(:rspec?).and_return(true)
-        runner.should_not_receive(:run)
+        allow(runner).to receive(:rspec?).and_return(true)
+        expect(runner).not_to receive(:run)
         runner.run_all
       end
     end
@@ -191,7 +191,7 @@ describe Guard::Spin::Runner do
 
   describe '.bundler?' do
     before do
-      Dir.stub(:pwd).and_return("")
+      allow(Dir).to receive(:pwd).and_return("")
     end
 
     context 'with no bundler option' do
@@ -199,21 +199,21 @@ describe Guard::Spin::Runner do
 
       context 'with Gemfile' do
         before do
-          File.should_receive(:exist?).with('/Gemfile').and_return(true)
+          expect(File).to receive(:exist?).with('/Gemfile').and_return(true)
         end
 
         it 'return true' do
-          subject.send(:bundler?).should be_true
+          expect(subject.send(:bundler?)).to be_truthy
         end
       end
 
       context 'with no Gemfile' do
         before do
-          File.should_receive(:exist?).with('/Gemfile').and_return(false)
+          expect(File).to receive(:exist?).with('/Gemfile').and_return(false)
         end
 
         it 'return false' do
-          subject.send(:bundler?).should be_false
+          expect(subject.send(:bundler?)).to be_falsey
         end
       end
     end
@@ -223,21 +223,21 @@ describe Guard::Spin::Runner do
 
       context 'with Gemfile' do
         before do
-          File.should_not_receive(:exist?)
+          expect(File).not_to receive(:exist?)
         end
 
         it 'return false' do
-          subject.send(:bundler?).should be_false
+          expect(subject.send(:bundler?)).to be_falsey
         end
       end
 
       context 'with no Gemfile' do
         before do
-          File.should_not_receive(:exist?)
+          expect(File).not_to receive(:exist?)
         end
 
         it 'return false' do
-          subject.send(:bundler?).should be_false
+          expect(subject.send(:bundler?)).to be_falsey
         end
       end
     end
@@ -247,21 +247,21 @@ describe Guard::Spin::Runner do
 
       context 'with Gemfile' do
         before do
-          File.should_receive(:exist?).with('/Gemfile').and_return(true)
+          expect(File).to receive(:exist?).with('/Gemfile').and_return(true)
         end
 
         it 'return true' do
-          subject.send(:bundler?).should be_true
+          expect(subject.send(:bundler?)).to be_truthy
         end
       end
 
       context 'with no Gemfile' do
         before do
-          File.should_receive(:exist?).with('/Gemfile').and_return(false)
+          expect(File).to receive(:exist?).with('/Gemfile').and_return(false)
         end
 
         it 'return false' do
-          subject.send(:bundler?).should be_false
+          expect(subject.send(:bundler?)).to be_falsey
         end
       end
     end
@@ -269,7 +269,7 @@ describe Guard::Spin::Runner do
 
   describe '.test_unit?' do
     before do
-      Dir.stub(:pwd).and_return("")
+      allow(Dir).to receive(:pwd).and_return("")
     end
 
     context 'with no test_unit option' do
@@ -277,21 +277,21 @@ describe Guard::Spin::Runner do
 
       context 'with Gemfile' do
         before do
-          File.should_receive(:exist?).with('/test/test_helper.rb').and_return(true)
+          expect(File).to receive(:exist?).with('/test/test_helper.rb').and_return(true)
         end
 
         it 'return true' do
-          subject.send(:test_unit?).should be_true
+          expect(subject.send(:test_unit?)).to be_truthy
         end
       end
 
       context 'with no Gemfile' do
         before do
-          File.should_receive(:exist?).with('/test/test_helper.rb').and_return(false)
+          expect(File).to receive(:exist?).with('/test/test_helper.rb').and_return(false)
         end
 
         it 'return false' do
-          subject.send(:test_unit?).should be_false
+          expect(subject.send(:test_unit?)).to be_falsey
         end
       end
     end
@@ -301,21 +301,21 @@ describe Guard::Spin::Runner do
 
       context 'with Gemfile' do
         before do
-          File.should_not_receive(:exist?)
+          expect(File).not_to receive(:exist?)
         end
 
         it 'return false' do
-          subject.send(:test_unit?).should be_false
+          expect(subject.send(:test_unit?)).to be_falsey
         end
       end
 
       context 'with no Gemfile' do
         before do
-          File.should_not_receive(:exist?)
+          expect(File).not_to receive(:exist?)
         end
 
         it 'return false' do
-          subject.send(:test_unit?).should be_false
+          expect(subject.send(:test_unit?)).to be_falsey
         end
       end
     end
@@ -325,21 +325,21 @@ describe Guard::Spin::Runner do
 
       context 'with Gemfile' do
         before do
-          File.should_receive(:exist?).with('/test/test_helper.rb').and_return(true)
+          expect(File).to receive(:exist?).with('/test/test_helper.rb').and_return(true)
         end
 
         it 'return true' do
-          subject.send(:test_unit?).should be_true
+          expect(subject.send(:test_unit?)).to be_truthy
         end
       end
 
       context 'with no Gemfile' do
         before do
-          File.should_receive(:exist?).with('/test/test_helper.rb').and_return(false)
+          expect(File).to receive(:exist?).with('/test/test_helper.rb').and_return(false)
         end
 
         it 'return false' do
-          subject.send(:test_unit?).should be_false
+          expect(subject.send(:test_unit?)).to be_falsey
         end
       end
     end
@@ -347,7 +347,7 @@ describe Guard::Spin::Runner do
 
   describe '.rspec?' do
     before do
-      Dir.stub(:pwd).and_return("")
+      allow(Dir).to receive(:pwd).and_return("")
     end
 
     context 'with no rspec option' do
@@ -355,21 +355,21 @@ describe Guard::Spin::Runner do
 
       context 'with Gemfile' do
         before do
-          File.should_receive(:exist?).with('/spec').and_return(true)
+          expect(File).to receive(:exist?).with('/spec').and_return(true)
         end
 
         it 'return true' do
-          subject.send(:rspec?).should be_true
+          expect(subject.send(:rspec?)).to be_truthy
         end
       end
 
       context 'with no Gemfile' do
         before do
-          File.should_receive(:exist?).with('/spec').and_return(false)
+          expect(File).to receive(:exist?).with('/spec').and_return(false)
         end
 
         it 'return false' do
-          subject.send(:rspec?).should be_false
+          expect(subject.send(:rspec?)).to be_falsey
         end
       end
     end
@@ -379,21 +379,21 @@ describe Guard::Spin::Runner do
 
       context 'with Gemfile' do
         before do
-          File.should_not_receive(:exist?)
+          expect(File).not_to receive(:exist?)
         end
 
         it 'return false' do
-          subject.send(:rspec?).should be_false
+          expect(subject.send(:rspec?)).to be_falsey
         end
       end
 
       context 'with no Gemfile' do
         before do
-          File.should_not_receive(:exist?)
+          expect(File).not_to receive(:exist?)
         end
 
         it 'return false' do
-          subject.send(:rspec?).should be_false
+          expect(subject.send(:rspec?)).to be_falsey
         end
       end
     end
@@ -403,21 +403,21 @@ describe Guard::Spin::Runner do
 
       context 'with Gemfile' do
         before do
-          File.should_receive(:exist?).with('/spec').and_return(true)
+          expect(File).to receive(:exist?).with('/spec').and_return(true)
         end
 
         it 'return true' do
-          subject.send(:rspec?).should be_true
+          expect(subject.send(:rspec?)).to be_truthy
         end
       end
 
       context 'with no Gemfile' do
         before do
-          File.should_receive(:exist?).with('/spec').and_return(false)
+          expect(File).to receive(:exist?).with('/spec').and_return(false)
         end
 
         it 'return false' do
-          subject.send(:rspec?).should be_false
+          expect(subject.send(:rspec?)).to be_falsey
         end
       end
     end

--- a/spec/guard/spin_spec.rb
+++ b/spec/guard/spin_spec.rb
@@ -1,59 +1,61 @@
 require 'spec_helper'
+require 'guard/compat/test/helper'
+
 
 describe Guard::Spin do
 
   describe '#initialize' do
     it "instantiates Runner with given options" do
-      Guard::Spin::Runner.should_receive(:new).with(:bundler => false)
+      expect(Guard::Spin::Runner).to receive(:new).with(:bundler => false)
       Guard::Spin.new({ :bundler => false })
     end
   end
 
   describe '.start' do
     it "calls Runner.kill_spin and Runner.launch_spin with 'Start'" do
-      subject.runner.should_receive(:kill_spin)
-      subject.runner.should_receive(:launch_spin).with('Start')
+      expect(subject.runner).to receive(:kill_spin)
+      expect(subject.runner).to receive(:launch_spin).with('Start')
       subject.start
     end
   end
 
   describe '.reload' do
     it "calls Runner.kill_spin and Runner.launch_spin with 'Reload'" do
-      subject.runner.should_receive(:kill_spin)
-      subject.runner.should_receive(:launch_spin).with('Reload')
+      expect(subject.runner).to receive(:kill_spin)
+      expect(subject.runner).to receive(:launch_spin).with('Reload')
       subject.reload
     end
   end
 
   describe '.run_all' do
     it "calls Runner.run_all" do
-      subject.runner.should_receive(:run_all)
+      expect(subject.runner).to receive(:run_all)
       subject.run_all
     end
   end
 
   describe '.run_on_change (for guard 1.0.x and earlier)' do
     it 'calls Runner.run with file name' do
-      subject.runner.should_receive(:run).with('file_name.rb')
+      expect(subject.runner).to receive(:run).with('file_name.rb')
       subject.run_on_change('file_name.rb')
     end
   end
 
   describe '.run_on_changes' do
     it "calls Runner.run with file name" do
-      subject.runner.should_receive(:run).with('file_name.rb')
+      expect(subject.runner).to receive(:run).with('file_name.rb')
       subject.run_on_changes('file_name.rb')
     end
 
     it "calls Runner.run with paths" do
-      subject.runner.should_receive(:run).with(['spec/controllers', 'spec/requests'])
+      expect(subject.runner).to receive(:run).with(['spec/controllers', 'spec/requests'])
       subject.run_on_changes(['spec/controllers', 'spec/requests'])
     end
   end
 
   describe '.stop' do
     it 'calls Runner.kill_spin' do
-      subject.runner.should_receive(:kill_spin)
+      expect(subject.runner).to receive(:kill_spin)
       subject.stop
     end
   end

--- a/spec/guard/spin_spec.rb
+++ b/spec/guard/spin_spec.rb
@@ -5,7 +5,7 @@ describe Guard::Spin do
   describe '#initialize' do
     it "instantiates Runner with given options" do
       Guard::Spin::Runner.should_receive(:new).with(:bundler => false)
-      Guard::Spin.new [], { :bundler => false }
+      Guard::Spin.new({ :bundler => false })
     end
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,5 +5,4 @@ ENV['GUARD_ENV'] = 'test'
 RSpec.configure do |config|
   config.filter_run :focus => true
   config.run_all_when_everything_filtered = true
-  config.treat_symbols_as_metadata_keys_with_true_values = true
 end


### PR DESCRIPTION
Bump to 0.4.0
Update to rspec 3.2 and update spec syntax.
Add guard-compat for guard plugin testing.
